### PR TITLE
Fixes & Add more tests to project

### DIFF
--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/KF2ServerUtils/WorkshopCollectionListBuilder.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/KF2ServerUtils/WorkshopCollectionListBuilder.cs
@@ -3,14 +3,14 @@ using System.Text;
 
 namespace KF2WorkshopUrlConverter.Core.KF2ServerUtils
 {
-    class WorkshopSectionCollectionListBuilder
+    class WorkshopCollectionListBuilder
     {
         private string _header;
         private string _footer;
         private Collection _collection;
         private string _format;
 
-        public WorkshopSectionCollectionListBuilder()
+        public WorkshopCollectionListBuilder()
         {
             SetDefaults();
         }
@@ -23,19 +23,19 @@ namespace KF2WorkshopUrlConverter.Core.KF2ServerUtils
             _format = "{1} {2}";
         }
 
-        public WorkshopSectionCollectionListBuilder WithCollection(Collection collection)
+        public WorkshopCollectionListBuilder WithCollection(Collection collection)
         {
             _collection = collection;
             return this;
         }
 
-        public WorkshopSectionCollectionListBuilder WithHeader(string header)
+        public WorkshopCollectionListBuilder WithHeader(string header)
         {
             _header = header;
             return this;
         }
 
-        public WorkshopSectionCollectionListBuilder WithFooter(string footer)
+        public WorkshopCollectionListBuilder WithFooter(string footer)
         {
             _footer = footer;
             return this;
@@ -50,7 +50,7 @@ namespace KF2WorkshopUrlConverter.Core.KF2ServerUtils
         ///         {1} Name of the Item
         ///         {2} Url of the Item
         /// </param>
-        public WorkshopSectionCollectionListBuilder WithFormat(string format)
+        public WorkshopCollectionListBuilder WithFormat(string format)
         {
             _format = format;
             return this;
@@ -63,12 +63,21 @@ namespace KF2WorkshopUrlConverter.Core.KF2ServerUtils
                 return string.Empty;
             }
             StringBuilder sb = new StringBuilder();
-            sb.AppendLine(_header);
+
+            if (!_header.Equals(string.Empty))
+            {
+                sb.AppendLine(_header);
+            }
+
             foreach (var item in _collection.Items)
             {
                 sb.AppendFormat(_format, item.Id, item.Name, item.Url).AppendLine();
             }
-            sb.AppendLine(_footer);
+
+            if (!_footer.Equals(string.Empty))
+            {
+                sb.AppendLine(_footer);
+            }
             return sb.ToString();
         }
     }

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/KF2WorkshopUrlConverter.Core.csproj
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/KF2WorkshopUrlConverter.Core.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.7" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.17" />
     <PackageReference Include="Mono.Options.Core" Version="1.0.0" />
   </ItemGroup>
 

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/Program.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/Program.cs
@@ -80,7 +80,7 @@ namespace KF2WorkshopUrlConverter.Core
                     .AppendLine($"### {collection.ItemCount} Items | Last Query: {DateTime.Now} ###");
                 string footer = $"## END of {collection.Name} ##";
 
-                string collectionList = new WorkshopSectionCollectionListBuilder()
+                string collectionList = new WorkshopCollectionListBuilder()
                     .WithHeader(header.ToString())
                     .WithCollection(collection)
                     .WithFooter(footer)

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/SteamWorkshop/Services/SteamWorkshopService.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Core/SteamWorkshop/Services/SteamWorkshopService.cs
@@ -16,25 +16,25 @@ namespace KF2WorkshopUrlConverter.Core.SteamWorkshop.Services
                 throw new NotASteamWorkshopUrlException("Not a Steam Workshop URL");
             }
             HtmlWeb web = new HtmlWeb();
-            HtmlDocument doc;
+            HtmlDocument pageDoc;
             try
             {
-                doc = web.Load(url);
+                pageDoc = web.Load(url);
             }
             catch (UriFormatException e)
             {
                 throw new UriFormatException("Must contain http:// or https:// on the URL.", e);
             }
-            if (!IsASteamWorkshopCollection(url))
+            if (!IsASteamWorkshopCollection(pageDoc))
             {
                 throw new NotACollectionException("This url is not a Steam Workshop collection");
             }
 
             string colId = Regex.Replace(url, @"[^0-9]", string.Empty);
-            string colName = doc.DocumentNode.SelectNodes("//div[@class='workshopItemTitle']")[0].InnerText;
+            string colName = pageDoc.DocumentNode.SelectNodes("//div[@class='workshopItemTitle']")[0].InnerText;
             List<Item> colItems = new List<Item>();
 
-            HtmlNodeCollection nodes = doc.DocumentNode.SelectNodes("//div[@class='collectionItemDetails']");
+            HtmlNodeCollection nodes = pageDoc.DocumentNode.SelectNodes("//div[@class='collectionItemDetails']");
             foreach (HtmlNode n in nodes)
             {
                 string ItemUrl = n.SelectSingleNode(".//a").Attributes["href"].Value;
@@ -49,17 +49,22 @@ namespace KF2WorkshopUrlConverter.Core.SteamWorkshop.Services
         public static bool IsASteamWorkshopCollection(string url)
         {
             HtmlWeb web = new HtmlWeb();
-            HtmlDocument doc;
+            HtmlDocument pageDoc;
             try
             {
-                doc = web.Load(url);
+                pageDoc = web.Load(url);
             }
             catch (UriFormatException e)
             {
                 throw new UriFormatException("Must contain http:// or https:// on the URL.", e);
             }
-            HtmlNodeCollection nodes = doc.DocumentNode.SelectNodes("//div[@class='collectionItemDetails']");
+            HtmlNodeCollection nodes = pageDoc.DocumentNode.SelectNodes("//div[@class='collectionItemDetails']");
             return nodes != null;
+        }
+
+        public static bool IsASteamWorkshopCollection(HtmlDocument document)
+        {
+            return document.DocumentNode.SelectNodes("//div[@class='collectionItemDetails']") != null;
         }
 
         public Item FetchItemFromUrl(string url)

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/KF2WorkshopUrlConverter.Test.csproj
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/KF2WorkshopUrlConverter.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
@@ -39,7 +39,7 @@ namespace KF2WorkshopUrlConverter.Test.Services
         }
 
         [Test]
-        public void SuccededToFetchTheProjectExampleCollection()
+        public void SucceedToFetchTheProjectExampleCollection()
         {
             var testUrl = "https://steamcommunity.com/sharedfiles/filedetails/?id=882417829";
             var collection = workshopService.FetchCollectionFromURL(testUrl);

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
@@ -1,5 +1,7 @@
+using KF2WorkshopUrlConverter.Core.SteamWorkshop.Exceptions;
 using KF2WorkshopUrlConverter.Core.SteamWorkshop.Services;
 using NUnit.Framework;
+using System;
 
 namespace KF2WorkshopUrlConverter.Test.Services
 {
@@ -11,8 +13,41 @@ namespace KF2WorkshopUrlConverter.Test.Services
         [Test]
         public void FailsToFetchCollectionFromInvalidUrlAndThrowAnException()
         {
-            var testUrl = "https://www.google.com.br";
-            Assert.That(() => workshopService.FetchCollectionFromURL(testUrl), Throws.Exception);
+            var testUrl = "randomTextAndNotAUrl";
+            Assert.That(() => workshopService.FetchCollectionFromURL(testUrl), Throws.TypeOf<NotASteamWorkshopUrlException>());
         }
+
+        [Test]
+        public void FailsToFetchCollectionFromValidUrlButNotASteamWorkshopUrlAndThrowAnException()
+        {
+            var testUrl = "https://google.com.br";
+            Assert.That(() => workshopService.FetchCollectionFromURL(testUrl), Throws.TypeOf<NotASteamWorkshopUrlException>());
+        }
+
+        [Test]
+        public void FailsToFetchCollectionFromValidSteamWorkshopUrlWithoutProtocolAndThrowAnException()
+        {
+            var testUrl = "steamcommunity.com/sharedfiles/filedetails/?id=882417829";
+            Assert.That(() => workshopService.FetchCollectionFromURL(testUrl), Throws.TypeOf<UriFormatException>());
+        }
+
+        [Test]
+        public void FailsToFetchCollectionFromASteamWorkshopItemUrlAndThrowAnException()
+        {
+            var testUrl = "https://steamcommunity.com/sharedfiles/filedetails/?id=650252240";
+            Assert.That(() => workshopService.FetchCollectionFromURL(testUrl), Throws.TypeOf<NotACollectionException>());
+        }
+
+        [Test]
+        public void SuccededToFetchTheProjectExampleCollection()
+        {
+            var testUrl = "https://steamcommunity.com/sharedfiles/filedetails/?id=882417829";
+            var collection = workshopService.FetchCollectionFromURL(testUrl);
+            Assert.IsTrue(collection.ItemCount == 1);
+            Assert.IsTrue(collection.Name.Equals("Map Collection Example"));
+            Assert.IsTrue(collection.Items[0].Url.Equals("https://steamcommunity.com/sharedfiles/filedetails/?id=650252240"));
+        }
+
+
     }
 }

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
@@ -47,7 +47,5 @@ namespace KF2WorkshopUrlConverter.Test.Services
             Assert.IsTrue(collection.Name.Equals("Map Collection Example"));
             Assert.IsTrue(collection.Items[0].Url.Equals("https://steamcommunity.com/sharedfiles/filedetails/?id=650252240"));
         }
-
-
     }
 }

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/Services/SteamWorkshopServiceTest.cs
@@ -6,11 +6,13 @@ using System;
 namespace KF2WorkshopUrlConverter.Test.Services
 {
     [TestFixture]
+    [Description("Tests related to KF2WorkshopUrlConverter.Core.SteamWorkshop.Services.SteamWorkshopService")]
     public class SteamWorkshopServiceTest
     {
         private readonly SteamWorkshopService workshopService = new SteamWorkshopService();
 
         [Test]
+        [Description("Trys to fetch a collection with an invalid url and throws a NotASteamWorkshopUrlException.")]
         public void FailsToFetchCollectionFromInvalidUrlAndThrowAnException()
         {
             var testUrl = "randomTextAndNotAUrl";
@@ -18,6 +20,7 @@ namespace KF2WorkshopUrlConverter.Test.Services
         }
 
         [Test]
+        [Description("Trys to fetch a collection with a valid url, but not a SteamWorkshop Url and throws a NotASteamWorkshopUrlException.")]
         public void FailsToFetchCollectionFromValidUrlButNotASteamWorkshopUrlAndThrowAnException()
         {
             var testUrl = "https://google.com.br";
@@ -25,6 +28,7 @@ namespace KF2WorkshopUrlConverter.Test.Services
         }
 
         [Test]
+        [Description("Trys to fetch a collection with a valid SteamWorkshop URL, but without protocol and throws an UriFormatException.")]
         public void FailsToFetchCollectionFromValidSteamWorkshopUrlWithoutProtocolAndThrowAnException()
         {
             var testUrl = "steamcommunity.com/sharedfiles/filedetails/?id=882417829";
@@ -32,6 +36,7 @@ namespace KF2WorkshopUrlConverter.Test.Services
         }
 
         [Test]
+        [Description("Trys to fetch a collection with a Item SteamWorkshop URL and throws a NotACollectionException.")]
         public void FailsToFetchCollectionFromASteamWorkshopItemUrlAndThrowAnException()
         {
             var testUrl = "https://steamcommunity.com/sharedfiles/filedetails/?id=650252240";
@@ -39,6 +44,7 @@ namespace KF2WorkshopUrlConverter.Test.Services
         }
 
         [Test]
+        [Description("Trys to fetch the Example Collection from SteamWorkshop and expects: 1 item, correct name & correct url from an item.")]
         public void SucceedToFetchTheProjectExampleCollection()
         {
             var testUrl = "https://steamcommunity.com/sharedfiles/filedetails/?id=882417829";

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
@@ -1,0 +1,44 @@
+﻿using KF2WorkshopUrlConverter.Core.KF2ServerUtils;
+using KF2WorkshopUrlConverter.Core.SteamWorkshop.Entities;
+using KF2WorkshopUrlConverter.Core.SteamWorkshop.Services;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KF2WorkshopUrlConverter.Test
+{
+    [TestFixture]
+    class CollectionListBuilderTest
+    {
+        private WorkshopCollectionListBuilder collectionListBuilder;
+
+        [SetUp]
+        public void Setup()
+        {
+            collectionListBuilder = new WorkshopCollectionListBuilder();
+        }
+
+        [Test]
+        public void GenerateEmptyListWithNoCollection()
+        {
+            var result = collectionListBuilder.Build();
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void GenerateListWithoutHeaderFooterOrFormat()
+        {
+            var collection = new Collection("a", "b", new List<Item>()
+            {
+                new Item("AnId", "RandomName")
+            });
+            var result = collectionListBuilder.WithCollection(collection).Build();
+            var resultExpected = $"RandomName {collection.Items[0].Url}" + Environment.NewLine;
+
+            Assert.IsNotEmpty(result);
+            Assert.IsTrue(result.Equals(resultExpected));
+        }
+
+    }
+}

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
@@ -19,7 +19,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
-        [Description("Try to generate a list with default values, expecting a empty string as result.")]
+        [Description("Trys to generate a list with default values, expecting a empty string as result.")]
         public void GenerateEmptyListWithNoCollection()
         {
             var result = collectionListBuilder.Build();
@@ -27,7 +27,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
-        [Description("Try to generate a list providing a collection of 1 item and not providing header, footer or an item format, expecting the default result.")]
+        [Description("Trys to generate a list providing a collection of 1 item and not providing header, footer or an item format, expecting the default result.")]
         public void GenerateListWithoutHeaderFooterOrFormat()
         {
             var collection = new Collection("a", "b", new List<Item>()
@@ -42,7 +42,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
-        [Description("Try to generate a list providing a collection of 1 item, an item format and not providing header or footer, expecting a custom result.")]
+        [Description("Trys to generate a list providing a collection of 1 item, an item format and not providing header or footer, expecting a custom result.")]
         public void GenerateListWithoutHeaderOrFooter()
         {
             var collection = new Collection("a", "b", new List<Item>()

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
@@ -7,7 +7,8 @@ using System.Collections.Generic;
 namespace KF2WorkshopUrlConverter.Test
 {
     [TestFixture]
-    class CollectionListBuilderTest
+    [Description("Tests related to KF2WorkshopUrlConverter.Core.KF2Utils.WorkshopCollectionListBuilder")]
+    class WorkshopCollectionListBuilderTest
     {
         private WorkshopCollectionListBuilder collectionListBuilder;
 
@@ -18,6 +19,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
+        [Description("Try to generate a list with default values, expecting a empty string as result.")]
         public void GenerateEmptyListWithNoCollection()
         {
             var result = collectionListBuilder.Build();
@@ -25,6 +27,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
+        [Description("Try to generate a list providing a collection of 1 item and not providing header, footer or an item format, expecting the default result.")]
         public void GenerateListWithoutHeaderFooterOrFormat()
         {
             var collection = new Collection("a", "b", new List<Item>()
@@ -39,6 +42,7 @@ namespace KF2WorkshopUrlConverter.Test
         }
 
         [Test]
+        [Description("Try to generate a list providing a collection of 1 item, an item format and not providing header or footer, expecting a custom result.")]
         public void GenerateListWithoutHeaderOrFooter()
         {
             var collection = new Collection("a", "b", new List<Item>()

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
@@ -1,10 +1,8 @@
 ﻿using KF2WorkshopUrlConverter.Core.KF2ServerUtils;
 using KF2WorkshopUrlConverter.Core.SteamWorkshop.Entities;
-using KF2WorkshopUrlConverter.Core.SteamWorkshop.Services;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace KF2WorkshopUrlConverter.Test
 {

--- a/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
+++ b/KF2 Workshop URL Converter/KF2WorkshopUrlConverter.Test/WorkshopCollectionListBuilderTest.cs
@@ -32,11 +32,24 @@ namespace KF2WorkshopUrlConverter.Test
                 new Item("AnId", "RandomName")
             });
             var result = collectionListBuilder.WithCollection(collection).Build();
-            var resultExpected = $"RandomName {collection.Items[0].Url}" + Environment.NewLine;
+            var resultExpected = $"RandomName https://steamcommunity.com/sharedfiles/filedetails/?id=AnId" + Environment.NewLine;
 
             Assert.IsNotEmpty(result);
             Assert.IsTrue(result.Equals(resultExpected));
         }
 
+        [Test]
+        public void GenerateListWithoutHeaderOrFooter()
+        {
+            var collection = new Collection("a", "b", new List<Item>()
+            {
+                new Item("AnId", "RandomName")
+            });
+            var result = collectionListBuilder.WithCollection(collection).WithFormat("{2} {1} {0}").Build();
+            var resultExpected = "https://steamcommunity.com/sharedfiles/filedetails/?id=AnId RandomName AnId" + Environment.NewLine;
+
+            Assert.IsNotEmpty(result);
+            Assert.IsTrue(result.Equals(resultExpected));
+        }
     }
 }


### PR DESCRIPTION
Resolves #1 
- Fixed the url on "FailsToFetchCollectionFromInvalidUrlAndThrowAnException" & added specific exception detection.
- Refactor on WorkshopCollectionListBuilder class
- Added Tests to SteamWorkshopServiceTest class:
  - FailsToFetchCollectionFromValidUrlButNotASteamWorkshopUrlAndThrowAnException
  - FailsToFetchCollectionFromValidSteamWorkshopUrlWithoutProtocolAndThrowAnException
  - FailsToFetchCollectionFromASteamWorkshopItemUrlAndThrowAnException
  - SucceedToFetchTheProjectExampleCollection
- Added Tests of WorkshopCollectionListBuilder
  - GenerateEmptyListWithNoCollection
  - GenerateListWithoutHeaderFooterOrFormat
  - GenerateListWithoutHeaderOrFooter
- Bump on Project Dependencies.